### PR TITLE
Update CLI 4.12.2

### DIFF
--- a/build.json
+++ b/build.json
@@ -9,7 +9,7 @@
         "i386": "ghcr.io/home-assistant/i386-base:3.13"
     },
     "args": {
-        "CLI_VERSION": "4.12.1",
+        "CLI_VERSION": "4.12.2",
         "RLWRAP_VERSION": "0.44"
     },
     "labels": {


### PR DESCRIPTION
Upstream release notes: <https://github.com/home-assistant/cli/releases/tag/4.12.2>