### PR TITLE
Strip unnecessary leading ha

### DIFF
--- a/rootfs/usr/bin/cli.sh
+++ b/rootfs/usr/bin/cli.sh
@@ -12,6 +12,9 @@ while true; do
         exit 10
     elif [ "$COMMAND" == "exit" ]; then
         exit
+    elif [ -z "${COMMAND##ha*}" ]; then
+        echo "Note: Leading 'ha' is not necessary in this HA CLI"
+        COMMAND=$(echo "$COMMAND" | cut -b 3-)
     fi
 
     echo "$COMMAND" | xargs ha


### PR DESCRIPTION
In the HA CLI the prompt already indicates that we are running in the HA
CLI (similar to virsh or other commands with built-in shell). However,
in regular shell the ha command needs to be used, so that is what most
documentation says. Note that 'ha' is not necessary and strip it from
the command.