### PR TITLE
Disambiguate `ha` and `hardware` commands

### DIFF
--- a/rootfs/usr/bin/cli.sh
+++ b/rootfs/usr/bin/cli.sh
@@ -12,7 +12,7 @@ while true; do
         exit 10
     elif [ "$COMMAND" == "exit" ]; then
         exit
-    elif [ -z "${COMMAND##ha*}" ]; then
+    elif [ -z "${COMMAND##ha *}" ]; then
         echo "Note: Leading 'ha' is not necessary in this HA CLI"
         COMMAND=$(echo "$COMMAND" | cut -b 3-)
     fi


### PR DESCRIPTION
Attempting to use the hardware command without a leading "ha" results in
the following error:

    ha > hardware
    Note: Leading 'ha' is not necessary in this HA CLI
    Error: unknown command "rdware" for "ha"

Checking that the command starts with "ha " (note the space) will ensure
that the command string actually starts with a call to `ha`.