### PR TITLE
Update Home Assistant CLI to 4.28.1

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -12,7 +12,7 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/plugin-cli/.*
 args:
-  CLI_VERSION: 4.28.0
+  CLI_VERSION: 4.28.1
   RLWRAP_VERSION: 0.45.2
 labels:
   io.hass.type: cli


### PR DESCRIPTION
Updates the Home Assistant CLI to v4.28.1

Release notes: <https://github.com/home-assistant/cli/releases/tag/4.28.1>