### PR TITLE
Make curl fail on server errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache --virtual .build-deps \
 
 # Install CLI
 ARG CLI_VERSION
-RUN curl -Lso /usr/bin/ha https://github.com/home-assistant/cli/releases/download/${CLI_VERSION}/ha_${BUILD_ARCH} \
+RUN curl -Lfso /usr/bin/ha https://github.com/home-assistant/cli/releases/download/${CLI_VERSION}/ha_${BUILD_ARCH} \
     && chmod a+x /usr/bin/ha
 
 COPY rootfs /


### PR DESCRIPTION
Make sure the build fails by asking curl to fail if there are server errors (such as 404).