### PR TITLE
Update rlwrap to 0.46.1 to fix partially repeated input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache --virtual .build-deps \
         build-base \
         readline-dev \
         ncurses-dev \
-    && curl -L -s "https://github.com/hanslub42/rlwrap/releases/download/v${RLWRAP_VERSION}/rlwrap-${RLWRAP_VERSION}.tar.gz" \
+    && curl -L -s "https://github.com/hanslub42/rlwrap/releases/download/${RLWRAP_VERSION}/rlwrap-${RLWRAP_VERSION}.tar.gz" \
         | tar zxvf - -C /usr/src/ \
     && cd rlwrap-${RLWRAP_VERSION} \
     && ./configure \

--- a/build.yaml
+++ b/build.yaml
@@ -13,7 +13,7 @@ cosign:
   identity: https://github.com/home-assistant/plugin-cli/.*
 args:
   CLI_VERSION: 4.29.0
-  RLWRAP_VERSION: 0.45.2
+  RLWRAP_VERSION: 0.46.1
 labels:
   io.hass.type: cli
   org.opencontainers.image.title: Home Assistant CLI Plugin


### PR DESCRIPTION
First five commands of every command are repeated on enter, the length changes on the length of the `-S` argument passed to `rlwrap`. This seems to be related to changes for readline v0.8.1/v0.8.2, as discussed in a similar issue: https://github.com/hanslub42/rlwrap/issues/168
With latest rlwrap release the issue is gone, fixes #127.

Also note that the latest release is missing `v` prefix in the git tag, thus it's been removed from the URL of the release tarball.