### PR TITLE
Add note about login command

### DIFF
--- a/rootfs/usr/bin/cli.sh
+++ b/rootfs/usr/bin/cli.sh
@@ -8,7 +8,9 @@ while true; do
     COMMAND="$(rlwrap -S $'\e[32mha > \e[0m' -H /tmp/.cli_history -o cat)"
 
     # Abort to host?
-    if [ "$COMMAND" == "login" ]; then
+    if [ "$COMMAND" == "help" ]; then
+        echo "Note: Use \"login\" to enter operating system shell"
+    elif [ "$COMMAND" == "login" ]; then
         exit 10
     elif [ "$COMMAND" == "exit" ]; then
         exit


### PR DESCRIPTION
Add a note about the "login" command which is provided by the cli.sh script itself at the top when using the help command.

Fixes: #129