### PR TITLE
Start HA CLI interactively

### DIFF
--- a/rootfs/usr/bin/cli.sh
+++ b/rootfs/usr/bin/cli.sh
@@ -19,6 +19,6 @@ while true; do
         COMMAND=$(echo "$COMMAND" | cut -b 3-)
     fi
 
-    echo "$COMMAND" | xargs ha
+    echo "$COMMAND" | xargs -o ha
     echo ""
 done


### PR DESCRIPTION
Use -o (--open-tty) to start the child with stdin as /dev/tty to allow interactive mode. This is required by some commands like the new device wipe command added with https://github.com/home-assistant/cli/pull/464.