### PR TITLE
Bump CLI to 4.36.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -12,7 +12,7 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/plugin-cli/.*
 args:
-  CLI_VERSION: 4.35.0
+  CLI_VERSION: 4.36.0
   RLWRAP_VERSION: 0.46.1
 labels:
   io.hass.type: cli


### PR DESCRIPTION
https://github.com/home-assistant/cli/releases/tag/4.36.0