### PR TITLE
Bump to Alpine 3.12 and CLI 4.37.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,10 @@
 image: ghcr.io/home-assistant/{arch}-hassio-cli
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.20
-  armhf: ghcr.io/home-assistant/armhf-base:3.20
-  armv7: ghcr.io/home-assistant/armv7-base:3.20
-  amd64: ghcr.io/home-assistant/amd64-base:3.20
-  i386: ghcr.io/home-assistant/i386-base:3.20
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.21
+  armhf: ghcr.io/home-assistant/armhf-base:3.21
+  armv7: ghcr.io/home-assistant/armv7-base:3.21
+  amd64: ghcr.io/home-assistant/amd64-base:3.21
+  i386: ghcr.io/home-assistant/i386-base:3.21
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
@@ -12,7 +12,7 @@ cosign:
   base_identity: https://github.com/home-assistant/docker-base/.*
   identity: https://github.com/home-assistant/plugin-cli/.*
 args:
-  CLI_VERSION: 4.36.0
+  CLI_VERSION: 4.37.0
   RLWRAP_VERSION: 0.46.1
 labels:
   io.hass.type: cli


### PR DESCRIPTION
CLI [v4.37.0](https://github.com/home-assistant/cli/releases/tag/4.37.0) changelog.