### PR TITLE
Bump CLI to version 5.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache --virtual .build-deps \
     && rm -rf /usr/src/*
 
 # Install CLI
-ARG CLI_VERSION=5.0.0
+ARG CLI_VERSION=5.1.0
 ARG TARGETARCH
 RUN \
     if [ -z "${TARGETARCH}" ]; then \


### PR DESCRIPTION
[Changelog 5.1.0](https://github.com/home-assistant/cli/releases/tag/5.1.0)