### PR TITLE
Harden Bash tab completion against shell expansion and code execution

### DIFF
--- a/rootfs/etc/ha-cli/.repl_rc
+++ b/rootfs/etc/ha-cli/.repl_rc
@@ -31,6 +31,13 @@ if command -v ha >/dev/null 2>&1; then
 
         # Universal completion handler - wraps everything as 'ha ...'
         __ha_repl_complete() {
+            # The generated ha completion evals the command words, so refuse
+            # to complete a line holding any shell-active character: it is
+            # literal text for ha but code to that eval.
+            if [[ $COMP_LINE == *[![:alnum:]\ ._:/=,+@-]* ]]; then
+                COMPREPLY=()
+                return
+            fi
             if [[ ${COMP_WORDS[0]} == "ha" ]]; then
                 # Explicit 'ha ...' - complete as-is, no prefixing needed
                 COMPREPLY=()
@@ -114,6 +121,10 @@ __ha_accept() {
 
 bind -x '"\C-m": __ha_accept'
 bind -x '"\C-j": __ha_accept'
+
+# Readline completes filenames for words that bypass the compspec, like
+# '$(': run from an empty directory so it finds nothing
+mkdir -p /run/ha-cli/empty && cd /run/ha-cli/empty
 
 # Unbind readline functions that accept or expand the line behind
 # __ha_accept's back: operate-and-get-next (C-o), edit-and-execute-command


### PR DESCRIPTION
The generated ha completion (cobra) runs `eval "${requestComp}"` on the command words. A backtick or $(...) anywhere on the line therefore ran an arbitrary command during tab completion, before any `login`. Refuse to complete a line holding any shell-active character so cobra's eval only ever sees inert `ha __complete <args>`, keeping command execution reachable only through `login`. The same guard drops the shell variable names bash-completion offered for $-words ($DIR<Tab> -> $DIRSTACK).

Also run the REPL from an empty directory so the filename completion bash does for words that bypass the compspec (like the '$(' opener) finds nothing.

Caveats, both cosmetic since REPL input reaches ha verbatim and never a shell:
- Completion inside `$(...)` is handled by bash's built-in command-substitution machinery, which skips our compspec entirely, so `$($<Tab>` still lists shell variables and `$(../<Tab>` still completes paths. Suppressing it would require taking over the tab key and reimplementing completion.
- An absolute path after `'$(' (e.g. $(/usr<Tab>)` still completes, since the empty-directory trick only covers relative lookups.