### PR TITLE
Bump CLI to v5.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
     bash-completion
 
 # Install CLI
-ARG CLI_VERSION=5.3.1
+ARG CLI_VERSION=5.4.0
 ARG TARGETARCH
 RUN \
     if [ -z "${TARGETARCH}" ]; then \


### PR DESCRIPTION
* https://github.com/home-assistant/cli/releases/tag/5.4.0